### PR TITLE
bugfix: remove empty string from ignore_paths

### DIFF
--- a/src/nblint.py
+++ b/src/nblint.py
@@ -9,6 +9,8 @@ def main():
     dir = os.environ["INPUT_DIRECTORY"]
     ignore_paths = os.environ["INPUT_IGNORE_PATHS"]
     ignore_paths = ignore_paths.split(",")
+    if "" in ignore_paths:
+        ignore_paths.remove("")
     notebooks = find_notebooks(dir, ignore_paths)
 
     checks = []


### PR DESCRIPTION
The empty string `""` will be included in `ignore_paths` if  `os.environ["INPUT_IGNORE_PATHS"]` is left empty or ends with a comma (eg. `test,`) , which will make the check skip all notebooks. This fix removes the empty string from the list.